### PR TITLE
ci(travis): remove build on Node v8 and add on Node v12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ notifications:
 node_js:
   - '10'
   - '11'
-  - '8'
+  - '12'
 script:
   - npm run test:prod && npm run build
 after_success:


### PR DESCRIPTION
Reasons to this change:

- Node 8 won't be supported after December 31st, 2019;
- Newer versions of commitizen and cz-conventional-changelog don't support Node 8.